### PR TITLE
Fix a bug in call(primitive)

### DIFF
--- a/lib/babl/operators/call.rb
+++ b/lib/babl/operators/call.rb
@@ -15,7 +15,7 @@ module Babl
                     when ::Proc then call(&arg)
                     when ::Hash then object(**arg.map { |k, v| [k.to_s.to_sym, v] }.to_h)
                     when ::Array then array(*arg)
-                    when ::String, ::Numeric, ::NilClass, ::TrueClass, ::FalseClass then unscoped.static(arg)
+                    when ::String, ::Numeric, ::NilClass, ::TrueClass, ::FalseClass then static(arg)
                     else raise ::Babl::InvalidTemplateError, "call() received invalid argument: #{arg}"
                     end
                 end

--- a/spec/operators/call_spec.rb
+++ b/spec/operators/call_spec.rb
@@ -6,12 +6,17 @@ describe ::Babl::Operators::Call do
     describe '#call' do
         let(:object) { nil }
 
-        context 'false' do
+        context 'primitive' do
             let(:template) { dsl.call(false) }
 
             it { expect(json).to eq false }
             it { expect(dependencies).to eq({}) }
             it { expect(documentation).to eq false }
+
+            context 'call primitive after a conditional' do
+                let(:template) { dsl.nullable.call(34) }
+                it { expect(json).to eq nil }
+            end
         end
 
         context 'block' do


### PR DESCRIPTION
`call(primitive value)` always returns the same value. I wrongly assumed it was safe to completely drop the rest of the chain in this case... but is not correct if the chain is interrupted in the middle by another operator (like `switch`, `nullable`, ...).

For instance `nullable.call(42)` always return 42, even if the current object is `Nil`, which is not right.

Fortunately, I don't think such a scenario is likely to occur in a real use case. There is no occurrence in our codebase.